### PR TITLE
improvement: make azure configuration variables optional

### DIFF
--- a/docs/ADVANCED_USAGE.md
+++ b/docs/ADVANCED_USAGE.md
@@ -32,4 +32,16 @@ configuration option by running the following command.
 oliver config set output_prefix "azure://container-name"
 ```
 
+### CosmosDB
+
+When using [Cromwell on Azure][coa], [CosmosDB][cosmos] is used as the metadata store for Cromwell. It can be extremely useful to peer into this metadata to understand failures that happen outside of Cromwell (for instance, within Azure Batch). Thus, we have integrated custom commands (such as `oliver cosmos`) to interrogate this database. If you wish to use this functionality, you'll need to set the following configuration parameters.
+
+```bash
+oliver config set azure_resource_group "YOUR RESOURCE GROUP NAME"
+oliver config set cosmos_account_name "YOUR COSMOSDB ACCOUNT NAME"
+```
+For more information, see our [configuration guide][configuration].
+
 [coa]: https://github.com/microsoft/CromwellOnAzure
+[configuration]: ./CONFIGURATION.md
+[cosmos]: https://azure.microsoft.com/en-us/services/cosmos-db/

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,8 +5,10 @@ dotfile is location at `~/.oliver_config`.
 
 The following key values pairs can be used to configure `oliver`:
 
-| Key                    | Description                                                    | Type   | Required | Default                 |
-| ---------------------- | -------------------------------------------------------------- | ------ | -------- | ----------------------- |
-| `cromwell_server`      | HTTP/HTTPS root URL for the Cromwell server to use by default. | String | True     | `http://localhost:8000` |
-| `cromwell_api_version` | Cromwell API version to use by default.                        | String | True     | `v1`                    |
-| `output_prefix`        | Prefix to append to file locations.                            | String | False    |                         |
+| Key                    | Description                                                                          | Type   | Required | Default                 |
+| ---------------------- | ------------------------------------------------------------------------------------ | ------ | -------- | ----------------------- |
+| `cromwell_server`      | HTTP/HTTPS root URL for the Cromwell server to use by default.                       | String | True     | `http://localhost:8000` |
+| `cromwell_api_version` | Cromwell API version to use by default.                                              | String | True     | `v1`                    |
+| `output_prefix`        | Prefix to append to file locations.                                                  | String | False    |                         |
+| `azure_resource_group` | If using Cromwell on Azure, resource group associated with your Cromwell instance.   | String | False    |                         |
+| `cosmos_account_name`  | If using Cromwell on Azure, name of CosmosDB associated with your Cromwell instance. | String | False    |                         |

--- a/oliver/config.py
+++ b/oliver/config.py
@@ -5,8 +5,6 @@ DEFAULT_LOCATION = "~/.oliver_config"
 DEFAULT_CONFIG = {
     "cromwell_server": "http://localhost:8000",
     "cromwell_api_version": "v1",
-    "azure_resource_group": "",
-    "cosmos_account_name": "",
 }
 
 

--- a/oliver/subcommands/configure.py
+++ b/oliver/subcommands/configure.py
@@ -3,8 +3,6 @@ from ..config import get_default_config, read_config, write_config
 QUESTION_MAPPING = {
     "cromwell_server": "What is the Cromwell server address",
     "cromwell_api_version": "What is the Cromwell API version",
-    "azure_resource_group": "What is the Azure resource group",
-    "cosmos_account_name": "What is the Cosmos account name",
 }
 
 


### PR DESCRIPTION
I suggest we make these optional since they won't apply to every user. What do you think? 