### PR TITLE
feature: use asyncio instead of requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,22 @@ jobs:
         run: sudo apt-get update && sudo apt-get install httpie -y
       - name: Start services
         run: docker-compose --project-name oliver up --build --detach
-      - name: Wait for Cromwell
+      - name: Wait for services to come available
         run: |
+          echo "Waiting for Cromwell to come up..."
           NEXT_WAIT_TIME=0
           until http HEAD http://localhost:8000 &> /dev/null || [ $NEXT_WAIT_TIME -eq 30 ]; do
             echo "Sleeping ${NEXT_WAIT_TIME} seconds..."
             sleep $(( NEXT_WAIT_TIME++ ))
           done
+
+          echo "Waiting for httpbin to come up..."
+          NEXT_WAIT_TIME=0
+          until http HEAD http://localhost:80 &> /dev/null || [ $NEXT_WAIT_TIME -eq 30 ]; do
+            echo "Sleeping ${NEXT_WAIT_TIME} seconds..."
+            sleep $(( NEXT_WAIT_TIME++ ))
+          done
+
           sleep 2
       - name: Seed database
         run: chmod +x seeds/seed.sh; seeds/seed.sh http://localhost:8000 seeds/wdl/hello.wdl
@@ -32,4 +41,4 @@ jobs:
           docker container run \
             --network oliver_default \
             oliver \
-            /bin/bash -c "python setup.py install && oliver configure --defaults && oliver config set cromwell_server http://cromwell:8000 && pytest tests"
+            /bin/bash -c "python setup.py install && oliver configure --defaults && oliver config set cromwell_server http://cromwell:8000 && pytest tests -v"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,20 @@ docker-compose up --build -d
 
 # Seed development environment (make sure Cromwell is live first!)
 chmod +x seeds/seed.sh
-seeds/seed.sh http://localhost:8000 seeds/wdl/simple.wdl
+seeds/seed.sh http://localhost:8000 seeds/wdl/hello.wdl
+```
+
+To reset your entire docker-compose environment, you can run the following:
+
+```bash
+docker-compose down
+
+docker image rm oliver:latest
+docker image rm oliver_cromwell:latest
+docker image rm mysql:5.7
+docker volume rm oliver_mysql_data
+
+docker-compose up --build -d
 ```
 
 ## Author

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
             - type: "bind"
               source: "./mocks/cromwell/db/init" 
               target: "/docker-entrypoint-initdb.d"
+    httpbin:
+        image: kennethreitz/httpbin
+        ports:
+            - 80:80
 
 volumes:
     mysql_data:

--- a/oliver/integrations/azure/cosmos.py
+++ b/oliver/integrations/azure/cosmos.py
@@ -7,7 +7,7 @@ import os
 
 from typing import Dict
 
-from ...lib import reporting
+from ...lib import api, reporting
 
 
 class CosmosAPI:
@@ -48,7 +48,7 @@ class CosmosAPI:
         )
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:

--- a/oliver/lib/api.py
+++ b/oliver/lib/api.py
@@ -219,7 +219,7 @@ class CromwellAPI:
             "excludeLabelAnd": excludeLabelAnds,
             "excludeLabelOr": excludeLabelOrs,
             "additionalQueryResultFields": additionalQueryResultFields,
-            "includeSubworkflows": includeSubworkflows,
+            "includeSubworkflows": str(includeSubworkflows),
         }
 
         _, data = await self._api_call("/api/workflows/{version}/query", params=params)

--- a/oliver/lib/parsing.py
+++ b/oliver/lib/parsing.py
@@ -10,7 +10,6 @@ from ..lib import constants, errors
 
 def is_url(url_string: str) -> bool:
     try:
-        print(url_string)
         scheme = urlparse(url_string).scheme
         return scheme == "http" or scheme == "https"
     except:

--- a/oliver/lib/workflows.py
+++ b/oliver/lib/workflows.py
@@ -130,8 +130,8 @@ async def get_workflows(
     workflows = await cromwell.get_workflows_query(
         includeSubworkflows=False,
         labels=labels,
-        ids=[cromwell_workflow_uuid],
-        names=[cromwell_workflow_name],
+        ids=[cromwell_workflow_uuid] if cromwell_workflow_uuid else None,
+        names=[cromwell_workflow_name] if cromwell_workflow_name else None,
         submission=submission,
     )
 

--- a/oliver/lib/workflows.py
+++ b/oliver/lib/workflows.py
@@ -7,7 +7,7 @@ from typing import Optional, List, Dict
 from . import api, batch, constants
 
 
-def get_workflows(
+async def get_workflows(
     cromwell: api.CromwellAPI,
     submission_time_hours_ago: int = None,
     oliver_job_name: str = None,
@@ -127,7 +127,7 @@ def get_workflows(
             - datetime.timedelta(hours=submission_time_hours_ago)
         ).replace(microsecond=0).isoformat("T") + "Z"
 
-    workflows = cromwell.get_workflows_query(
+    workflows = await cromwell.get_workflows_query(
         includeSubworkflows=False,
         labels=labels,
         ids=[cromwell_workflow_uuid],

--- a/oliver/subcommands/__template__.py
+++ b/oliver/subcommands/__template__.py
@@ -9,7 +9,7 @@ SUBCOMMAND_NAME = "__template__"
 SUBCOMMAND_ALIASES = []
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:

--- a/oliver/subcommands/aggregate.py
+++ b/oliver/subcommands/aggregate.py
@@ -31,32 +31,29 @@ def process_output(dest_folder: str, output: str, dry_run: bool = False):
         os.system(cmd)
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:
         args (Dict): Arguments parsed from the command line.
     """
 
-    cromwell = api.CromwellAPI(
-        server=args["cromwell_server"], version=args["cromwell_api_version"]
-    )
     output_folder = args.get("root-output-folder")
     workflows = []
 
     if args.get("workflow"):
-        workflows = _workflows.get_workflows(
+        workflows = await _workflows.get_workflows(
             cromwell, cromwell_workflow_uuid=args.get("workflow"),
         )
     elif args.get("batches_absolute"):
-        workflows = _workflows.get_workflows(
+        workflows = await _workflows.get_workflows(
             cromwell,
             batches=args.get("batches_absolute"),
             relative_batching=False,
             batch_interval_mins=args.get("batch_interval_mins"),
         )
     elif args.get("batches_relative"):
-        workflows = _workflows.get_workflows(
+        workflows = await _workflows.get_workflows(
             cromwell,
             batches=args.get("batches_relative"),
             batch_interval_mins=args.get("batch_interval_mins"),
@@ -78,7 +75,7 @@ def call(args: Dict):
 
         if args.get("append_job_name"):
             name = oliver.get_oliver_name(
-                cromwell.get_workflows_metadata(workflow.get("id"))
+                await cromwell.get_workflows_metadata(workflow.get("id"))
             )
             if name == "<not set>":
                 name = "__UNKNOWN__"

--- a/oliver/subcommands/aws.py
+++ b/oliver/subcommands/aws.py
@@ -4,10 +4,10 @@ import os
 from typing import Dict
 
 from ..integrations.aws import debug
-from ..lib import args as _args, errors
+from ..lib import api, args as _args, errors
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:

--- a/oliver/subcommands/azure.py
+++ b/oliver/subcommands/azure.py
@@ -4,10 +4,10 @@ import os
 from typing import Dict
 
 from ..integrations.azure import cosmos
-from ..lib import errors
+from ..lib import api, errors
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the cosmos.
     
     Args:

--- a/oliver/subcommands/batches.py
+++ b/oliver/subcommands/batches.py
@@ -19,16 +19,12 @@ SUBCOMMAND_NAME = "batches"
 SUBCOMMAND_ALIASES = ["b"]
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:
         args (Dict): Arguments parsed from the command line.
     """
-
-    cromwell = api.CromwellAPI(
-        server=args["cromwell_server"], version=args["cromwell_api_version"],
-    )
 
     batches = True
     relative = None
@@ -40,7 +36,7 @@ def call(args: Dict):
         batches = args.get("batches_absolute")
         relative = False
 
-    workflows = _workflows.get_workflows(
+    workflows = await _workflows.get_workflows(
         cromwell,
         batches=batches,
         relative_batching=relative,
@@ -74,7 +70,7 @@ def call(args: Dict):
         # job groups
         if args.get("show_oliver_job_groups"):
             metadatas = {
-                w.get("id"): cromwell.get_workflows_metadata(w.get("id"))
+                w.get("id"): await cromwell.get_workflows_metadata(w.get("id"))
                 for w in batch_workflows
             }
             r["Job Groups"] = ", ".join(

--- a/oliver/subcommands/config.py
+++ b/oliver/subcommands/config.py
@@ -3,11 +3,11 @@ import sys
 
 from typing import Dict
 
-from ..lib import errors
+from ..lib import api, errors
 from ..lib.config import get_default_config, read_config, write_config
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:

--- a/oliver/subcommands/configure.py
+++ b/oliver/subcommands/configure.py
@@ -2,6 +2,7 @@ import argparse
 
 from typing import Dict
 
+from ..lib import api
 from ..lib.config import get_default_config, read_config, write_config
 
 QUESTION_MAPPING = {
@@ -15,7 +16,7 @@ def ask(question, default):
     return input(f"{question} (default: {default})? ")
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:

--- a/oliver/subcommands/inputs.py
+++ b/oliver/subcommands/inputs.py
@@ -6,17 +6,14 @@ from typing import Dict
 from ..lib import api, errors
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:
         args (Dict): Arguments parsed from the command line.
     """
 
-    cromwell = api.CromwellAPI(
-        server=args["cromwell_server"], version=args["cromwell_api_version"]
-    )
-    metadata = cromwell.get_workflows_metadata(args["workflow-id"])
+    metadata = await cromwell.get_workflows_metadata(args["workflow-id"])
 
     if not metadata.get("submittedFiles", {}).get("inputs"):
         errors.report(

--- a/oliver/subcommands/inspect.py
+++ b/oliver/subcommands/inspect.py
@@ -12,17 +12,14 @@ def report_failure(failure, indent, step=2, offset=2):
         report_failure(f, indent + step)
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:
         args (Dict): Arguments parsed from the command line.
     """
 
-    cromwell = api.CromwellAPI(
-        server=args["cromwell_server"], version=args["cromwell_api_version"]
-    )
-    metadata = cromwell.get_workflows_metadata(args["workflow-id"])
+    metadata = await cromwell.get_workflows_metadata(args["workflow-id"])
 
     oliver_job_name = metadata.get("labels", {}).get(constants.OLIVER_JOB_NAME_KEY, "")
     oliver_group_name = metadata.get("labels", {}).get(

--- a/oliver/subcommands/kill.py
+++ b/oliver/subcommands/kill.py
@@ -5,17 +5,14 @@ from typing import Dict
 from ..lib import api, reporting
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:
         args (Dict): Arguments parsed from the command line.
     """
 
-    cromwell = api.CromwellAPI(
-        server=args["cromwell_server"], version=args["cromwell_api_version"]
-    )
-    resp = cromwell.post_workflows_abort(args["workflow-id"])
+    resp = await cromwell.post_workflows_abort(args["workflow-id"])
 
     if not resp.get("id"):
         reporting.print_error_as_table(resp["status"], resp["message"])

--- a/oliver/subcommands/logs.py
+++ b/oliver/subcommands/logs.py
@@ -5,17 +5,14 @@ from typing import Dict
 from ..lib import api, errors, reporting
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:
         args (Dict): Arguments parsed from the command line.
     """
 
-    cromwell = api.CromwellAPI(
-        server=args["cromwell_server"], version=args["cromwell_api_version"]
-    )
-    logs = cromwell.get_workflows_logs(args["workflow-id"])
+    logs = await cromwell.get_workflows_logs(args["workflow-id"])
     results = []
 
     for name, call in logs["calls"].items():

--- a/oliver/subcommands/outputs.py
+++ b/oliver/subcommands/outputs.py
@@ -18,16 +18,13 @@ def get_outputs(
     return results
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:
         args (Dict): Arguments parsed from the command line.
     """
 
-    cromwell = api.CromwellAPI(
-        server=args["cromwell_server"], version=args["cromwell_api_version"]
-    )
     results = get_outputs(
         cromwell, args["workflow-id"], output_prefix=args.get("output_prefix"),
     )

--- a/oliver/subcommands/runtime.py
+++ b/oliver/subcommands/runtime.py
@@ -6,17 +6,14 @@ from typing import Dict
 from ..lib import api, errors, reporting
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:
         args (Dict): Arguments parsed from the command line.
     """
 
-    cromwell = api.CromwellAPI(
-        server=args["cromwell_server"], version=args["cromwell_api_version"]
-    )
-    metadata = cromwell.get_workflows_metadata(args["workflow-id"])
+    metadata = await cromwell.get_workflows_metadata(args["workflow-id"])
     if not metadata.get("calls"):
         reporting.print_error_as_table(metadata["status"], metadata["message"])
         return

--- a/oliver/subcommands/status.py
+++ b/oliver/subcommands/status.py
@@ -18,16 +18,12 @@ from ..lib import (
 )
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:
         args (Dict): Arguments parsed from the command line.
     """
-
-    cromwell = api.CromwellAPI(
-        server=args["cromwell_server"], version=args["cromwell_api_version"],
-    )
 
     batches = None
     relative = None
@@ -39,7 +35,7 @@ def call(args: Dict):
         batches = args.get("batches_absolute")
         relative = False
 
-    workflows = _workflows.get_workflows(
+    workflows = await _workflows.get_workflows(
         cromwell=cromwell,
         submission_time_hours_ago=args["submission_time"],
         oliver_job_name=args["job_name"],
@@ -55,7 +51,9 @@ def call(args: Dict):
         opt_into_reporting_succeeded_jobs=args["show_succeeded_jobs"],
     )
 
-    metadatas = {w["id"]: cromwell.get_workflows_metadata(w["id"]) for w in workflows}
+    metadatas = {
+        w["id"]: await cromwell.get_workflows_metadata(w["id"]) for w in workflows
+    }
 
     call_names_to_consider = args.get("failed_calls")
     if call_names_to_consider:

--- a/oliver/subcommands/submit.py
+++ b/oliver/subcommands/submit.py
@@ -7,16 +7,12 @@ from ..lib import api, args as _args, errors, reporting, utils
 from ..lib.parsing import parse_workflow, parse_workflow_inputs
 
 
-def call(args: Dict):
+async def call(args: Dict, cromwell: api.CromwellAPI):
     """Execute the subcommand.
     
     Args:
         args (Dict): Arguments parsed from the command line.
     """
-
-    cromwell = api.CromwellAPI(
-        server=args["cromwell_server"], version=args["cromwell_api_version"]
-    )
 
     workflow_args = parse_workflow(args["workflow"])
     (
@@ -35,7 +31,7 @@ def call(args: Dict):
             print(f"{key} = {value}")
         return
 
-    results = [cromwell.post_workflows(**workflow_args)]
+    results = [await cromwell.post_workflows(**workflow_args)]
     reporting.print_dicts_as_table(results, args["grid_style"])
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ boto3==1.11.9
 logzero==1.5.0
 pendulum==2.0.5
 pytest==5.3.5
+pytest-asyncio==0.10.0
 requests==2.22.0
 tabulate==0.8.6
 tzlocal==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp==3.6.2
 azure-cosmos==3.1.2
 boto3==1.11.9
 logzero==1.5.0

--- a/scripts/oliver
+++ b/scripts/oliver
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
+import asyncio
 import argparse
 import logging
 import logzero
 import sys
 
 from logzero import logger
-from oliver.lib import args as _args, errors, config as _config
+from oliver.lib import api, args as _args, errors, config as _config
 from oliver.subcommands import (
     aws,
     azure,
@@ -61,7 +62,7 @@ def ensure_required_args(args):
         )
 
 
-if __name__ == "__main__":
+async def main():
     parser = argparse.ArgumentParser(
         description="An opinionated Cromwell orchestration system."
     )
@@ -105,4 +106,10 @@ if __name__ == "__main__":
     elif args.get("debug"):
         logzero.loglevel(logging.DEBUG)
 
-    args["func"](args)
+    cromwell = api.CromwellAPI(server=args["cromwell_server"], version=args["cromwell_api_version"])
+    await args["func"](args, cromwell)
+    await cromwell.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/tests/oliver/lib/test_api.py
+++ b/tests/oliver/lib/test_api.py
@@ -1,13 +1,67 @@
+import pytest
+
 from oliver.lib import api, config
 
 
-def test_get_workflows():
+@pytest.mark.asyncio
+async def test_get_workflows():
     c = config.read_config()
     cromwell = api.CromwellAPI(
         server=c.get("cromwell_server"), version=c.get("cromwell_api_version")
     )
-    results = cromwell.get_workflows_query()
+    results = await cromwell.get_workflows_query()
 
     assert len(results) == 5
     for result in results:
         assert result.get("status") == "Succeeded"
+
+    await cromwell.close()
+
+
+@pytest.mark.asyncio
+async def test_api_get():
+    c = config.read_config()
+    cromwell = api.CromwellAPI(
+        server="http://httpbin:80", version=c.get("cromwell_api_version")
+    )
+
+    (code, response) = await cromwell._api_call(
+        "/get", params={"includeSubworkflows": "true"}
+    )
+
+    assert code == 200
+    assert response.get("args", {}).get("includeSubworkflows") == "true"
+
+    await cromwell.close()
+
+
+@pytest.mark.asyncio
+async def test_api_post():
+    c = config.read_config()
+    cromwell = api.CromwellAPI(
+        server="http://httpbin:80", version=c.get("cromwell_api_version")
+    )
+
+    data = {
+        "workflowSource": None,
+        "workflowUrl": "http://my-test-url/hello.wdl",
+        "workflowInputs": "{'hello.text': 'Hello, world!'}",
+        "workflowOptions": "{}",
+        "labels": "{}",
+    }
+
+    (code, response) = await cromwell._api_call("/post", data=data, method="POST")
+
+    assert code == 200
+    assert response.get("files", {}).get("labels") == "{}"
+    assert (
+        response.get("files", {}).get("workflowInputs")
+        == "{'hello.text': 'Hello, world!'}"
+    )
+    assert (
+        response.get("files", {}).get("workflowUrl") == "http://my-test-url/hello.wdl"
+    )
+    assert response.get("files", {}).get("workflowOptions") == "{}"
+    assert "workflowSource" not in response.get("files", {})
+
+    await cromwell.close()


### PR DESCRIPTION
Asyncio appears to increase network heavy workloads by some non-marginal percentage. For example, using `oliver batches -g` without asyncio took 4:34 and with asyncio took 3:20.

Heads up to @jsunny23 and @adthrasher, as this will affect how we write code moving forward. I have not exhaustively tested every command, so please let me know if you run into issues.