### PR TITLE
Various small updates to API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
     cromwell:
         build: "mocks/cromwell"
-        ports: 
+        ports:
             - 8000:8000
         entrypoint: ["/bin/bash", "-c", "wait-for-it.sh mysql-db:3306 -t 120 -- java -Dconfig.file=/app/cromwell.conf -jar /app/cromwell.jar server"]
     mysql-db:
@@ -15,10 +15,10 @@ services:
             - 3307:3306
         volumes:
             - type: "volume"
-              source: "mysql_data" 
+              source: "mysql_data"
               target: "/var/lib/mysql"
             - type: "bind"
-              source: "./mocks/cromwell/db/init" 
+              source: "./mocks/cromwell/db/init"
               target: "/docker-entrypoint-initdb.d"
     httpbin:
         image: kennethreitz/httpbin

--- a/docs/getting-started/submit-jobs.md
+++ b/docs/getting-started/submit-jobs.md
@@ -3,7 +3,7 @@
 One of the novel features provided by Oliver is the ease with which workflow
 inputs, options, and labels can be set dynamically on the command line.
 Typically when submitting a workflow, one must craft and POST one or more `workflowInputs`,
-`workflowOptions`, and `labels` JSON files to Cromwell. This can be cumbersome 
+`workflowOptions`, and `labels` JSON files to Cromwell. This can be cumbersome
 — especially when you have thousands of workflows to run.
 
 ## Dynamic Parameter Parsing
@@ -59,7 +59,7 @@ oliver submit workflow.wdl defaults.json sample_name=SJBALL101_D --dry-run
 
 ## Job Names and Groups
 
-You can submit jobs with a "Oliver Job Name" (`-j`) and "Oliver Job Group" (`-g`) to mimic the capabilities of an HPC. Under the hood, Oliver adds these as labels to the workflow. In most Oliver commands, you can then specify these options to restrict results. 
+You can submit jobs with a "Oliver Job Name" (`-j`) and "Oliver Job Group" (`-g`) to mimic the capabilities of an HPC. Under the hood, Oliver adds these as labels to the workflow. In most Oliver commands, you can then specify these options to restrict results.
 
 For instance, if you wished to submit a group of samples with the same job name and then track their status:
 

--- a/mocks/cromwell/Dockerfile
+++ b/mocks/cromwell/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "St. Jude Cloud Team <support@stjude.cloud>"
 ADD cromwell.conf /app/cromwell.conf
 RUN apt-get update \
     && apt-get install -y --no-install-recommends wget git \
-    && rm -rf /var/lib/apt/lists/* 
+    && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/vishnubob/wait-for-it.git ${BIN_DIRECTORY}/wait-for-it/
 ENV PATH "${BIN_DIRECTORY}/wait-for-it/:${PATH}"

--- a/mocks/cromwell/cromwell.conf
+++ b/mocks/cromwell/cromwell.conf
@@ -6,7 +6,7 @@ webservice {
 }
 
 system {
-  io { 
+  io {
     number-of-attempts = 5
   }
 

--- a/oliver/subcommands/abort.py
+++ b/oliver/subcommands/abort.py
@@ -33,6 +33,15 @@ async def call(args: Dict[str, Any], cromwell: api.CromwellAPI) -> None:
         opt_into_reporting_running_jobs=True
     )
 
+    if args.get("cromwell_workflow_uuid"):
+        resp = await cromwell.post_workflows_abort(args["cromwell_workflow_uuid"])
+
+        if not resp.get("id"):
+            reporting.print_error_as_table(resp["status"], resp["message"])
+        else:
+            results = [{"Workflow ID": resp["id"], "Status": resp["status"]}]
+            reporting.print_dicts_as_table(results)
+
     for w in workflows:
         resp = await cromwell.post_workflows_abort(w["id"])
 
@@ -64,7 +73,7 @@ def register_subparser(
     )
     _args.add_batches_interval_arg(subcommand)
     scope_predicate.add_argument(
-        "-w", "--cromwell-workflow-uuid", help="Workflow UUID you wish to retry."
+        "-w", "--cromwell-workflow-uuid", help="Workflow UUID you wish to abort."
     )
     _args.add_oliver_job_group_args(scope_predicate)
     _args.add_oliver_job_name_args(scope_predicate)

--- a/oliver/subcommands/abort.py
+++ b/oliver/subcommands/abort.py
@@ -30,7 +30,7 @@ async def call(args: Dict[str, Any], cromwell: api.CromwellAPI) -> None:
         batches=batches,
         batch_interval_mins=args["batch_interval_mins"],
         relative_batching=relative,
-        opt_into_reporting_running_jobs=True
+        opt_into_reporting_running_jobs=True,
     )
 
     if args.get("cromwell_workflow_uuid"):
@@ -65,7 +65,7 @@ def register_subparser(
     subcommand = subparser.add_parser(
         "abort",
         aliases=["kill", "k"],
-        help="Abort a workflow running on a Cromwell server.",
+        help="Abort workflows running on a Cromwell server.",
     )
     scope_predicate = subcommand.add_mutually_exclusive_group(required=True)
     _args.add_batches_group(
@@ -75,8 +75,10 @@ def register_subparser(
     scope_predicate.add_argument(
         "-w", "--cromwell-workflow-uuid", help="Workflow UUID you wish to abort."
     )
-    _args.add_oliver_job_group_args(scope_predicate)
-    _args.add_oliver_job_name_args(scope_predicate)
+    scope_predicate.add_argument(
+        "-g", "--job-group", help="Job group name you wish to abort."
+    )
+    scope_predicate.add_argument("-j", "--job-name", help="Job name you wish to abort.")
     subcommand.add_argument(
         "--grid-style",
         help="Any valid `tablefmt` for python-tabulate.",

--- a/oliver/subcommands/aggregate.py
+++ b/oliver/subcommands/aggregate.py
@@ -19,11 +19,12 @@ def process_output(dest_folder: str, output: str, dry_run: bool = False) -> None
 
         return
 
-    cmd = f"cp {output} {dest_folder}"
-    if dry_run:
-        print(cmd)
-    else:
-        os.system(cmd)
+    if output:
+        cmd = f"cp {output} {dest_folder}"
+        if dry_run:
+            print(cmd)
+        else:
+            os.system(cmd)
 
 
 async def call(args: Dict[str, Any], cromwell: api.CromwellAPI) -> None:

--- a/oliver/subcommands/logs.py
+++ b/oliver/subcommands/logs.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 from ..lib import api, errors, reporting
 
 
-async def get_logs(cromwell: api.CromwellAPI, workflow_id: str) -> List[Dict]:
+async def get_logs(cromwell: api.CromwellAPI, workflow_id: str) -> List[Dict[str, str]]:
     """Get logs from a workflow ID.
 
     Cromwell has REST API for getting logs, but it excludes sub-workflows.
@@ -20,11 +20,11 @@ async def get_logs(cromwell: api.CromwellAPI, workflow_id: str) -> List[Dict]:
         List[Dict]: List of log files for the workflow
     """
     metadata = await cromwell.get_workflows_metadata(workflow_id)
-    results = []
+    results: List[Dict[str, str]] = []
     for name, call in metadata["calls"].items():
         for process in call:
             if "subWorkflowId" in process:
-                results = await get_logs(cromwell, process.get("subWorkflowId"))
+                results += await get_logs(cromwell, process.get("subWorkflowId"))
                 continue
 
             attempt = process.get("attempt")

--- a/oliver/subcommands/logs.py
+++ b/oliver/subcommands/logs.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 
 from ..lib import api, errors, reporting
 
+
 async def get_logs(cromwell: api.CromwellAPI, workflow_id: str) -> List[Dict]:
     """Get logs from a workflow ID.
 
@@ -60,6 +61,7 @@ async def get_logs(cromwell: api.CromwellAPI, workflow_id: str) -> List[Dict]:
                 }
             )
     return results
+
 
 async def call(args: Dict[str, Any], cromwell: api.CromwellAPI) -> None:
     """Execute the subcommand.


### PR DESCRIPTION
One outstanding issue is that the steps view for `status` doesn't display anything for subworkflow steps. The cause is the same issue I resolved for printing subworkflow logs (Cromwell REST API excludes sub-workflows), but the `status` code is more intricate than the `logs` command, and I don't think it's worth the effort to resolve at this time.