### PR TITLE
Allow empty optional outputs

### DIFF
--- a/oliver/integrations/azure/aggregate.py
+++ b/oliver/integrations/azure/aggregate.py
@@ -20,6 +20,9 @@ def process_output_azure(
             )
         return
 
+    if not output:
+        return
+
     if not azure_storage_account:
         errors.report(
             f"Must include Azure blob storage account name in config!",


### PR DESCRIPTION
Empty outputs currently cause the `azure aggregate` command to fail.

This commit is cherrypicked from `a-frantz/api-updates` since it addresses a critical bug.