### PR TITLE
fix: fixes batching when some workflows aren't started

### DIFF
--- a/oliver/subcommands/batches.py
+++ b/oliver/subcommands/batches.py
@@ -87,7 +87,8 @@ async def call(args: Dict[str, Any], cromwell: api.CromwellAPI) -> None:
             )
 
         # start time
-        _sorted_workflows = sorted(batch_workflows, key=lambda x: x["start"]) # type: ignore
+        batch_workflows_with_times = [b for b in batch_workflows if b.get("start") != None]
+        _sorted_workflows = sorted(batch_workflows_with_times, key=lambda x: x.get("start")) # type: ignore
         earliest_start_time = min([x.get("start") for x in _sorted_workflows])
         r["Start Time"] = reporting.localize_date(earliest_start_time)
 

--- a/oliver/subcommands/batches.py
+++ b/oliver/subcommands/batches.py
@@ -87,7 +87,7 @@ async def call(args: Dict[str, Any], cromwell: api.CromwellAPI) -> None:
             )
 
         # start time
-        batch_workflows_with_times = [b for b in batch_workflows if b.get("start") != None]
+        batch_workflows_with_times = [b for b in batch_workflows if b.get("start") is not None]
         _sorted_workflows = sorted(batch_workflows_with_times, key=lambda x: x.get("start")) # type: ignore
         earliest_start_time = min([x.get("start") for x in _sorted_workflows])
         r["Start Time"] = reporting.localize_date(earliest_start_time)


### PR DESCRIPTION
This PR fixes an issue in the batching code. Namely, the code currently assumes that the `start` key is present, which is not always true for workflows that haven't started. As such, we now don't assume that and instead prefilter the response to only look through jobs that have the key.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).

